### PR TITLE
API addition, internal changes

### DIFF
--- a/lib/BadFaith/AcceptCharset.php
+++ b/lib/BadFaith/AcceptCharset.php
@@ -49,24 +49,6 @@ class AcceptCharset extends AcceptLike
     }
 
     /**
-     * @param array $properties the array this method always gets
-     * @return Accept the object version of that array
-     */
-    static function __set_state(array $properties)
-    {
-        parent::__set_state($properties);
-        $accept = new AcceptCharset();
-        foreach ($properties as $key=>$prop) {
-            if (!property_exists('AcceptLike', $key)) {
-                if (property_exists($accept, $key)) {
-                    $accept->$key = $prop;
-                }
-            }
-        }
-        return $accept;
-    }
-
-    /**
      * Initializes attributes unique to this subclass.
      */
     function init()

--- a/lib/BadFaith/AcceptCharsetList.php
+++ b/lib/BadFaith/AcceptCharsetList.php
@@ -35,13 +35,4 @@ namespace BadFaith;
 class AcceptCharsetList extends AcceptLikeList
 {
     const ELEMENT_CLASS = 'AcceptCharset';
-
-    /**
-     * Calls the appropriate initializer.
-     * @param string|null $headerStr
-     */
-    public function __construct($headerIsh = null)
-    {
-        parent::__construct($headerIsh);
-    }
 }

--- a/lib/BadFaith/AcceptEncoding.php
+++ b/lib/BadFaith/AcceptEncoding.php
@@ -49,24 +49,6 @@ class AcceptEncoding extends AcceptLike
     }
 
     /**
-     * @param array $properties the array this method always gets
-     * @return Accept the object version of that array
-     */
-    static function __set_state(array $properties)
-    {
-        parent::__set_state($properties);
-        $accept = new AcceptEncoding();
-        foreach ($properties as $key=>$prop) {
-            if (!property_exists('AcceptLike', $key)) {
-                if (property_exists($accept, $key)) {
-                    $accept->$key = $prop;
-                }
-            }
-        }
-        return $accept;
-    }
-
-    /**
      * Initializes attributes unique to this subclass.
      */
     function init()

--- a/lib/BadFaith/AcceptEncodingList.php
+++ b/lib/BadFaith/AcceptEncodingList.php
@@ -35,12 +35,4 @@ namespace BadFaith;
 class AcceptEncodingList extends AcceptLikeList
 {
     const ELEMENT_CLASS = 'AcceptEncoding';
-    /**
-     * Calls the appropriate initializer.
-     * @param string|null $headerStr
-     */
-    public function __construct($headerIsh = null)
-    {
-        parent::__construct($headerIsh);
-    }
 }

--- a/lib/BadFaith/AcceptItemInterface.php
+++ b/lib/BadFaith/AcceptItemInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BadFaith;
+
+interface AcceptItemInterface
+{
+    /**
+     * @return string
+     */
+    function getPref();
+
+    /**
+     * @return double
+     */
+    function getQuality();
+}

--- a/lib/BadFaith/AcceptLanguage.php
+++ b/lib/BadFaith/AcceptLanguage.php
@@ -50,24 +50,6 @@ class AcceptLanguage extends AcceptLike
     }
 
     /**
-     * @param array $properties the array this method always gets
-     * @return Accept the object version of that array
-     */
-    static function __set_state(array $properties)
-    {
-        parent::__set_state($properties);
-        $accept = new AcceptLanguage();
-        foreach ($properties as $key => $prop) {
-            if (!property_exists('AcceptLike', $key)) {
-                if (property_exists($accept, $key)) {
-                    $accept->$key = $prop;
-                }
-            }
-        }
-        return $accept;
-    }
-
-    /**
      * Initializes attributes unique to this subclass.
      */
     function init()

--- a/lib/BadFaith/AcceptLanguageList.php
+++ b/lib/BadFaith/AcceptLanguageList.php
@@ -35,12 +35,4 @@ namespace BadFaith;
 class AcceptLanguageList extends AcceptLikeList
 {
     const ELEMENT_CLASS = 'AcceptLanguage';
-    /**
-     * Calls the appropriate initializer.
-     * @param string|null $headerStr
-     */
-    public function __construct($headerIsh = null)
-    {
-        parent::__construct($headerIsh);
-    }
 }

--- a/lib/BadFaith/AcceptLike.php
+++ b/lib/BadFaith/AcceptLike.php
@@ -31,7 +31,7 @@ namespace BadFaith;
  * @package BadFaith
  * @author William Milton
  */
-class AcceptLike
+class AcceptLike implements AcceptItemInterface
 {
 
     public $pref;
@@ -46,6 +46,22 @@ class AcceptLike
         if ($headerStr) {
             $this->initWithStr($headerStr);
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPref()
+    {
+        return $this->pref;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQuality()
+    {
+        return $this->q;
     }
 
     /**

--- a/lib/BadFaith/AcceptLike.php
+++ b/lib/BadFaith/AcceptLike.php
@@ -53,12 +53,13 @@ class AcceptLike
      */
     static function __set_state(array $properties)
     {
-        $acceptLike = new AcceptLike();
+        $acceptLike = new static();
         foreach ($properties as $key=>$prop) {
             if (property_exists($acceptLike, $key)) {
                 $acceptLike->$key = $prop;
             }
         }
+
         return $acceptLike;
     }
 

--- a/lib/BadFaith/AcceptLikeList.php
+++ b/lib/BadFaith/AcceptLikeList.php
@@ -84,8 +84,8 @@ class AcceptLikeList
      */
     protected static function elementClass()
     {
-        $factory = get_called_class();
-        $class = $factory::ELEMENT_CLASS;
+        $class = static::ELEMENT_CLASS;
+
         return __NAMESPACE__ . '\\' . $class;
     }
 

--- a/lib/BadFaith/AcceptLikeList.php
+++ b/lib/BadFaith/AcceptLikeList.php
@@ -34,8 +34,11 @@ namespace BadFaith;
  */
 class AcceptLikeList
 {
-
+    /**
+     * @var ItemContainer
+     */
     public $items;
+
     const ELEMENT_CLASS = 'AcceptLike';
 
     /**
@@ -52,6 +55,14 @@ class AcceptLikeList
     }
 
     /**
+     * @return AcceptItemInterface
+     */
+    public function getPreferred()
+    {
+        return $this->items->top();
+    }
+
+    /**
      * Helper for initializing with a string.
      * @param string $headerStr
      */
@@ -64,16 +75,20 @@ class AcceptLikeList
      * Given an Accept* request-header string, returns an array of AcceptLike
      * objects.
      * @param string $headerStr
-     * @return array
+     * @return ItemContainer
      */
     public static function prefParse($headerStr)
     {
+        $items = new ItemContainer;
+
         $parts = self::prefSplit($headerStr);
         $class = self::elementClass();
-        $f = function ($str) use ($class) {
-            return new $class($str);
-        };
-        return array_map($f, $parts);
+
+        foreach ($parts as $entity) {
+            $items->insert(new $class($entity));
+        }
+
+        return $items;
     }
 
     /**
@@ -100,6 +115,7 @@ class AcceptLikeList
         $parts = array_filter(explode(',', $prefWithParams));
         $parts = array_map('trim', $parts);
         reset($parts);
+
         return $parts;
     }
 }

--- a/lib/BadFaith/ItemContainer.php
+++ b/lib/BadFaith/ItemContainer.php
@@ -2,18 +2,50 @@
 
 namespace BadFaith;
 
-class ItemContainer extends \SplHeap {
+class ItemContainer implements \IteratorAggregate, \Countable
+{
+    protected $items = array();
+
+    public function insert(AcceptItemInterface $item) {
+        foreach ($this->items as $i => $check) {
+            if (1 === $this->compare($item, $check)) {
+                array_splice($this->items, $i, 0, array($item));
+                return;
+            }
+        }
+
+        array_push($this->items, $item);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->items);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function count()
+    {
+        return count($this->items);
+    }
+
+    public function top()
+    {
+        reset($this->items);
+
+        return current($this->items);
+    }
+
     /**
      * @param AcceptItemInterface
      * @param AcceptItemInterface
      */
-    public function compare($value1, $value2)
+    protected function compare($value1, $value2)
     {
-        // Can't do typehinting because of E_STRICT 
-        if (!($value1 instanceof AcceptItemInterface) || !($value2 instanceof AcceptItemInterface)) {
-            throw new \UnexpectedValueException("Comparables must implement AcceptItemInterface");
-        }
-
-        return ((double)$value1->getQuality() < (double)$value2->getQuality() ? -1 : 1);
+        return ((double)$value1->getQuality() <= (double)$value2->getQuality() ? -1 : 1);
     }
 }

--- a/lib/BadFaith/ItemContainer.php
+++ b/lib/BadFaith/ItemContainer.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BadFaith;
+
+class ItemContainer extends \SplHeap {
+    /**
+     * @param AcceptItemInterface
+     * @param AcceptItemInterface
+     */
+    public function compare($value1, $value2)
+    {
+        // Can't do typehinting because of E_STRICT 
+        if (!($value1 instanceof AcceptItemInterface) || !($value2 instanceof AcceptItemInterface)) {
+            throw new \UnexpectedValueException("Comparables must implement AcceptItemInterface");
+        }
+
+        return ((double)$value1->getQuality() < (double)$value2->getQuality() ? -1 : 1);
+    }
+}

--- a/lib/BadFaith/Negotiator.php
+++ b/lib/BadFaith/Negotiator.php
@@ -112,4 +112,28 @@ class Negotiator
 
         return __NAMESPACE__ . '\\' . $class;
     }
+
+    /**
+     * @param string|null
+     * @return string|array
+     */
+    function getPreferred($type = null)
+    {
+    }
+
+    /**
+     * @param string
+     * @param string|array
+     */
+    function setPriority($type, $value)
+    {
+    }
+
+    /**
+     * @param string
+     * @return string
+     */
+    function getBestVariant($type)
+    {
+    }
 }

--- a/lib/BadFaith/Negotiator.php
+++ b/lib/BadFaith/Negotiator.php
@@ -109,6 +109,7 @@ class Negotiator
             $class = 'AcceptLanguageList';
             break;
         }
+
         return __NAMESPACE__ . '\\' . $class;
     }
 }

--- a/lib/BadFaith/Negotiator.php
+++ b/lib/BadFaith/Negotiator.php
@@ -38,6 +38,8 @@ class Negotiator
 
     public $headerLists = array();
 
+    public $variants = array();
+
     static protected $keys = array(
         'accept',
         'accept_charset',
@@ -119,21 +121,15 @@ class Negotiator
      */
     function getPreferred($type = null)
     {
-    }
+        if (null === $type) {
+            $return = array();
+            foreach ($this->headerLists as $name => $list) {
+                $return[$name] = $list->getPreferred()->getPref();
+            }
+        } else {
+            $return = $this->headerLists["accept_{$type}"]->getPreferred()->getPref();
+        }
 
-    /**
-     * @param string
-     * @param string|array
-     */
-    function setPriority($type, $value)
-    {
-    }
-
-    /**
-     * @param string
-     * @return string
-     */
-    function getBestVariant($type)
-    {
+        return $return;
     }
 }

--- a/lib/BadFaith/Negotiator.php
+++ b/lib/BadFaith/Negotiator.php
@@ -38,6 +38,13 @@ class Negotiator
 
     public $headerLists = array();
 
+    static protected $keys = array(
+        'accept',
+        'accept_charset',
+        'accept_encoding',
+        'accept_language',
+    );
+
     /**
      * Constructor that initializes with given dict or $_SERVER.
      * @param array $headers a dict of header strings
@@ -49,7 +56,6 @@ class Negotiator
         } else {
             $this->headersFromArg($headers);
         }
-        $this->initLists();
     }
 
     /**
@@ -57,15 +63,13 @@ class Negotiator
      */
     function headersFromGlobals()
     {
-        $keys = array(
-            'accept',
-            'accept_charset',
-            'accept_encoding',
-            'accept_language',
-        );
-        foreach ($keys as $key) {
-            $this->headerLiterals[$key] = $_SERVER['HTTP_' . strtoupper($key)];
+        $headers = array();
+
+        foreach (static::$keys as $key) {
+            $headers[$key] = $_SERVER['HTTP_' . strtoupper($key)];
         }
+
+        $this->headersFromArg($headers);
     }
 
     /**
@@ -73,17 +77,11 @@ class Negotiator
      */
     function headersFromArg(array $arg)
     {
-        foreach ($arg as $key => $value) {
-            $this->headerLiterals[$key] = $value;
-        }
-    }
+        foreach (static::$keys as $key) {
+            $value = array_key_exists($key, $arg) ? $arg[$key] : '';
 
-    /**
-     * Initializes the list objects for the different Accept* headers.
-     */
-    function initLists()
-    {
-        foreach ($this->headerLiterals as $key => $value) {
+            $this->headerLiterals[$key] = $value;
+
             $class = $this->listClass($key);
             $this->headerLists[$key] = new $class($value);
         }

--- a/tests/BadFaith/Tests/AcceptCharsetListTest.php
+++ b/tests/BadFaith/Tests/AcceptCharsetListTest.php
@@ -33,7 +33,8 @@
 
 namespace BadFaith\Tests;
 
-use AcceptEncodingList;
+use BadFaith\AcceptEncodingList;
+use BadFaith\ItemContainer;
 
 class AcceptEncodingListTest extends \PHPUnit_Framework_TestCase
 {
@@ -44,7 +45,7 @@ class AcceptEncodingListTest extends \PHPUnit_Framework_TestCase
     {
         $this->headers = array (
             'accept' => 'text/html;level=2;q=0.7,text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'acceptEncoding' => 'gzip,deflate,sdch',
+            'acceptEncoding' => 'gzip,deflate;q=0.5,sdch;q=0.8',
             'acceptLanguage' => 'en-US,en;q=0.8',
             'acceptCharset' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
         );
@@ -53,7 +54,10 @@ class AcceptEncodingListTest extends \PHPUnit_Framework_TestCase
             'deflate',
             'sdch',
         );
-        $this->encodingParsed = array(
+
+        $this->encodingParsed = new ItemContainer;
+
+        $this->encodingParsed->insert(
             \BadFaith\AcceptEncoding::__set_state(
                 array(
                     'pref' => 'gzip',
@@ -61,7 +65,10 @@ class AcceptEncodingListTest extends \PHPUnit_Framework_TestCase
                     'q' => '1.0',
                     'params' => array(),
                 )
-            ),
+            )
+        );
+
+        $this->encodingParsed->insert(
             \BadFaith\AcceptEncoding::__set_state(
                 array(
                     'pref' => 'deflate',
@@ -69,7 +76,10 @@ class AcceptEncodingListTest extends \PHPUnit_Framework_TestCase
                     'q' => '1.0',
                     'params' => array(),
                 )
-            ),
+            )
+        );
+
+        $this->encodingParsed->insert(
             \BadFaith\AcceptEncoding::__set_state(
                 array(
                     'pref' => 'sdch',
@@ -77,7 +87,7 @@ class AcceptEncodingListTest extends \PHPUnit_Framework_TestCase
                     'q' => '1.0',
                     'params' => array(),
                 )
-            ),
+            )
         );
     }
 

--- a/tests/BadFaith/Tests/AcceptCharsetListTest.php
+++ b/tests/BadFaith/Tests/AcceptCharsetListTest.php
@@ -45,7 +45,7 @@ class AcceptEncodingListTest extends \PHPUnit_Framework_TestCase
     {
         $this->headers = array (
             'accept' => 'text/html;level=2;q=0.7,text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-            'acceptEncoding' => 'gzip,deflate;q=0.5,sdch;q=0.8',
+            'acceptEncoding' => 'gzip,deflate;q=1,sdch;q=1',
             'acceptLanguage' => 'en-US,en;q=0.8',
             'acceptCharset' => 'ISO-8859-1,utf-8;q=0.7,*;q=0.3',
         );

--- a/tests/BadFaith/Tests/AcceptEncodingListTest.php
+++ b/tests/BadFaith/Tests/AcceptEncodingListTest.php
@@ -34,6 +34,7 @@
 namespace BadFaith\Tests;
 
 use AcceptCharsetList;
+use BadFaith\ItemContainer;
 
 class AcceptCharsetListTest extends \PHPUnit_Framework_TestCase
 {
@@ -53,7 +54,10 @@ class AcceptCharsetListTest extends \PHPUnit_Framework_TestCase
             'utf-8;q=0.7',
             '*;q=0.3',
         );
-        $this->charsetParsed = array(
+
+        $this->charsetParsed = new ItemContainer;
+
+        $this->charsetParsed->insert(
             \BadFaith\AcceptCharset::__set_state(
                 array(
                     'pref' => 'ISO-8859-1',
@@ -61,7 +65,10 @@ class AcceptCharsetListTest extends \PHPUnit_Framework_TestCase
                     'q' => '1.0',
                     'params' => array(),
                 )
-            ),
+            )
+        );
+
+        $this->charsetParsed->insert(
             \BadFaith\AcceptCharset::__set_state(
                 array(
                     'pref' => 'utf-8',
@@ -69,7 +76,10 @@ class AcceptCharsetListTest extends \PHPUnit_Framework_TestCase
                     'q' => '0.7',
                     'params' => array(),
                 )
-            ),
+            )
+        );
+
+        $this->charsetParsed->insert(
             \BadFaith\AcceptCharset::__set_state(
                 array(
                     'pref' => '*',
@@ -77,7 +87,7 @@ class AcceptCharsetListTest extends \PHPUnit_Framework_TestCase
                     'q' => '0.3',
                     'params' => array(),
                 )
-            ),
+            )
         );
     }
 

--- a/tests/BadFaith/Tests/AcceptLanguageListTest.php
+++ b/tests/BadFaith/Tests/AcceptLanguageListTest.php
@@ -34,6 +34,7 @@
 namespace BadFaith\Tests;
 
 use AcceptLanguageList;
+use BadFaith\ItemContainer;
 
 class AcceptLanguageListTest extends \PHPUnit_Framework_TestCase
 {
@@ -52,7 +53,10 @@ class AcceptLanguageListTest extends \PHPUnit_Framework_TestCase
             'en-US',
             'en;q=0.8',
         );
-        $this->languageParsed = array(
+
+        $this->languageParsed = new ItemContainer;
+
+        $this->languageParsed->insert(
             \BadFaith\AcceptLanguage::__set_state(
                 array(
                     'pref' => 'en-US',
@@ -61,7 +65,10 @@ class AcceptLanguageListTest extends \PHPUnit_Framework_TestCase
                     'q' => '1.0',
                     'params' => array(),
                 )
-            ),
+            )
+        );
+
+        $this->languageParsed->insert(
             \BadFaith\AcceptLanguage::__set_state(
                 array(
                     'pref' => 'en',
@@ -69,7 +76,7 @@ class AcceptLanguageListTest extends \PHPUnit_Framework_TestCase
                     'q' => '0.8',
                     'params' => array(),
                 )
-            ),
+            )
         );
     }
 

--- a/tests/BadFaith/Tests/AcceptLikeListTest.php
+++ b/tests/BadFaith/Tests/AcceptLikeListTest.php
@@ -34,6 +34,7 @@
 namespace BadFaith\Tests;
 
 use AcceptLikeList;
+use BadFaith\ItemContainer;
 
 class AcceptLikeListTest extends \PHPUnit_Framework_TestCase
 {
@@ -54,42 +55,57 @@ class AcceptLikeListTest extends \PHPUnit_Framework_TestCase
             'application/xml;q=0.9',
             '*/*;q=0.8'
         );
-        $this->acceptParsed = array(
+
+        $this->acceptParsed = new ItemContainer;
+
+        $this->acceptParsed->insert(
             \BadFaith\AcceptLike::__set_state(
                 array(
                     'pref' => 'text/html',
                     'params' => array('level' => '2'),
                     'q' => '0.7',
                 )
-            ),
+            )
+        );
+
+        $this->acceptParsed->insert(
             \BadFaith\AcceptLike::__set_state(
                 array(
                     'pref' => 'text/html',
                     'params' => array(),
                     'q' => 1.0,
                 )
-            ),
+            )
+        );
+
+        $this->acceptParsed->insert(
             \BadFaith\AcceptLike::__set_state(
                 array(
                     'pref' => 'application/xhtml+xml',
                     'params' => array(),
                     'q' => 1.0,
                 )
-            ),
+            )
+        );
+
+        $this->acceptParsed->insert(
             \BadFaith\AcceptLike::__set_state(
                 array(
                     'pref' => 'application/xml',
                     'params' => array(),
                     'q' => 0.9,
                 )
-            ),
+            )
+        );
+
+        $this->acceptParsed->insert(
             \BadFaith\AcceptLike::__set_state(
                 array(
                     'pref' => '*/*',
                     'params' => array(),
                     'q' => 0.8,
                 )
-            ),
+            )
         );
     }
 

--- a/tests/BadFaith/Tests/AcceptListTest.php
+++ b/tests/BadFaith/Tests/AcceptListTest.php
@@ -34,6 +34,7 @@
 namespace BadFaith\Tests;
 
 use AcceptList;
+use BadFaith\ItemContainer;
 
 class AcceptListTest extends \PHPUnit_Framework_TestCase
 {
@@ -55,7 +56,10 @@ class AcceptListTest extends \PHPUnit_Framework_TestCase
             'application/xml;q=0.9',
             '*/*;q=0.8'
         );
-        $this->acceptParsed = array(
+
+        $this->acceptParsed = new ItemContainer;
+
+        $this->acceptParsed->insert(
             \BadFaith\Accept::__set_state(
                 array(
                     'pref' => 'text/html',
@@ -64,7 +68,10 @@ class AcceptListTest extends \PHPUnit_Framework_TestCase
                     'type' => 'text',
                     'subtype' => 'html',
                 )
-            ),
+            )
+        );
+
+        $this->acceptParsed->insert(
             \BadFaith\Accept::__set_state(
                 array(
                     'pref' => 'text/html',
@@ -73,7 +80,10 @@ class AcceptListTest extends \PHPUnit_Framework_TestCase
                     'type' => 'text',
                     'subtype' => 'html',
                 )
-            ),
+            )
+        );
+
+        $this->acceptParsed->insert(
             \BadFaith\Accept::__set_state(
                 array(
                     'pref' => 'application/xhtml+xml',
@@ -82,7 +92,10 @@ class AcceptListTest extends \PHPUnit_Framework_TestCase
                     'type' => 'application',
                     'subtype' => 'xhtml+xml',
                 )
-            ),
+            )
+        );
+
+        $this->acceptParsed->insert(
             \BadFaith\Accept::__set_state(
                 array(
                     'pref' => 'application/xml',
@@ -91,7 +104,10 @@ class AcceptListTest extends \PHPUnit_Framework_TestCase
                     'type' => 'application',
                     'subtype' => 'xml',
                 )
-            ),
+            )
+        );
+
+        $this->acceptParsed->insert(
             \BadFaith\Accept::__set_state(
                 array(
                     'pref' => '*/*',
@@ -100,7 +116,7 @@ class AcceptListTest extends \PHPUnit_Framework_TestCase
                     'type' => '*',
                     'subtype' => '*',
                 )
-            ),
+            )
         );
     }
 

--- a/tests/BadFaith/Tests/ItemCollectionTest.php
+++ b/tests/BadFaith/Tests/ItemCollectionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BadFaith\Tests;
+
+use BadFaith\ItemContainer;
+
+    // In case autoloading is not present
+//    require __DIR__ . '/ItemStub.php';
+
+/**
+ * @covers BadFaith\ItemContainer
+ */
+class ItemContainerTest extends \PHPUnit_Framework_TestCase {
+    public function itemProvider()
+    {
+        return array(
+            array(
+                array('one', 'two', 'three'), array('one' => 1, 'three' => 0.5, 'two' => 0.8)
+              , array('one', 'two', 'three'), array('three' => 0.3, 'one' => 0.5, 'two' => 0.5)
+            )
+        );
+    }
+
+    /**
+     * @dataProvider itemProvider
+     */
+    public function testExpectedOrder($expected, $given)
+    {
+        $container = new ItemContainer;
+        foreach ($given as $key => $q) {
+            $container->insert(new ItemStub($key, $q));
+        }
+
+        $this->assertEquals(count($expected), $container->count());
+
+        $i = 0;
+        foreach ($container as $item) {
+            $this->assertEquals($expected[$i++], $item->getPref());
+        }
+    }
+}

--- a/tests/BadFaith/Tests/ItemStub.php
+++ b/tests/BadFaith/Tests/ItemStub.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BadFaith\Tests;
+
+use BadFaith\AcceptItemInterface;
+
+class ItemStub implements AcceptItemInterface
+{
+    /**
+     * @var string
+     */
+    public $pref;
+
+    /**
+     * @var double
+     */
+    public $q;
+
+    /**
+     * @param string
+     * @param int
+     */
+    public function __construct($pref, $quality)
+    {
+        $this->pref = $pref;
+        $this->q    = $quality;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPref()
+    {
+        return $this->pref;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getQuality()
+    {
+        return $this->q;
+    }
+}

--- a/tests/BadFaith/Tests/NegotiatorTest.php
+++ b/tests/BadFaith/Tests/NegotiatorTest.php
@@ -26,7 +26,7 @@
 
 namespace BadFaith\Tests;
 
-use Negotiator;
+use BadFaith\Negotiator;
 
 /**
  * Negotiator Test
@@ -64,7 +64,7 @@ class NegotiatorTest extends \PHPUnit_Framework_TestCase
     public function testInitAcceptsWithNothing()
     {
         $_SERVER = $this->server;
-        $negotiator = new \BadFaith\Negotiator();
+        $negotiator = new Negotiator();
 
         $this->assertEquals(
             $_SERVER['HTTP_ACCEPT'],
@@ -75,11 +75,21 @@ class NegotiatorTest extends \PHPUnit_Framework_TestCase
     public function testInitAcceptsWithArg()
     {
         $headers = $this->headers;
-        $negotiator = new \BadFaith\Negotiator($headers);
+        $negotiator = new Negotiator($headers);
 
         $this->assertEquals(
             $headers['accept'],
             $negotiator->headerLiterals['accept']
         );
+    }
+
+    public function testFaultTolerence()
+    {
+        $missing = $this->server;
+        unset($missing['HTTP_ACCEPT_CHARSET']);
+
+        $negotiator = new Negotiator($missing);
+
+        $this->assertGreaterThan(count($missing), count($negotiator->headerLists));
     }
 }

--- a/tests/BadFaith/Tests/NegotiatorTest.php
+++ b/tests/BadFaith/Tests/NegotiatorTest.php
@@ -117,4 +117,17 @@ class NegotiatorTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals($expected, $negotiator->getPreferred());
     }
+
+    public function testGetBestVariant()
+    {
+        $client = 'fr,en;q=0.8,en-us;q=0.5';
+        $server = 'en-us,ar,en';
+
+        $headers = $this->headers;
+        $headers['accept_language'] = $client;
+
+        $negotiator = new Negotiator($headers, array('accept_language' => $server));
+
+        $this->assertEquals('en', $negotiator->getBestVariant('language'));
+    }
 }

--- a/tests/BadFaith/Tests/NegotiatorTest.php
+++ b/tests/BadFaith/Tests/NegotiatorTest.php
@@ -38,6 +38,10 @@ class NegotiatorTest extends \PHPUnit_Framework_TestCase
 {
     protected $server;
 
+    protected $headers;
+
+    protected $media_ranges;
+
     public function setUp()
     {
         $this->server = array (
@@ -91,5 +95,26 @@ class NegotiatorTest extends \PHPUnit_Framework_TestCase
         $negotiator = new Negotiator($missing);
 
         $this->assertGreaterThan(count($missing), count($negotiator->headerLists));
+    }
+
+    public function testGetPreferredString()
+    {
+        $negotiator = new Negotiator($this->headers);
+
+        $this->assertEquals('gzip', $negotiator->getPreferred('encoding'));
+    }
+
+    public function testGetPreferredArray()
+    {
+        $negotiator = new Negotiator($this->headers);
+
+        $expected = array(
+            'accept' => 'text/html'
+          , 'accept_charset' => 'ISO-8859-1'
+          , 'accept_encoding' => 'gzip'
+          , 'accept_language' => 'en-US'
+        );
+
+        $this->assertEquals($expected, $negotiator->getPreferred());
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,14 +9,25 @@
  * file that was distributed with this source code.
  */
 
-require_once __DIR__.'/../lib/BadFaith/Negotiator.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptLike.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptLikeList.php';
-require_once __DIR__.'/../lib/BadFaith/Accept.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptCharset.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptEncoding.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptLanguage.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptList.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptCharsetList.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptEncodingList.php';
-require_once __DIR__.'/../lib/BadFaith/AcceptLanguageList.php';
+    $loaderFile = dirname(__DIR__) . '/vendor/autoload.php';
+
+    if (file_exists($loaderFile)) {
+        $loader = require_once $loaderFile;
+
+        $loader->add('BadFaith\\Tests', __DIR__);
+        $loader->register();
+    } else {
+        require_once __DIR__.'/../lib/BadFaith/AcceptItemInterface.php';
+        require_once __DIR__.'/../lib/BadFaith/ItemContainer.php';
+        require_once __DIR__.'/../lib/BadFaith/Negotiator.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptLike.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptLikeList.php';
+        require_once __DIR__.'/../lib/BadFaith/Accept.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptCharset.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptEncoding.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptLanguage.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptList.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptCharsetList.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptEncodingList.php';
+        require_once __DIR__.'/../lib/BadFaith/AcceptLanguageList.php';
+    }


### PR DESCRIPTION
Bug fix: yes
Feature addition: yes
Backwards compatibility break: yes
Tests pass: yes
Tickets: #5

This PR replaces #6
- In some cases browsers do not send all 4 Accept headers, now make sure they're set if nothing given
- I created a unit test to simulate this then code to fix the issue
- Code was refactored to take advantage of late static binding, removing much duplicate code in classes that extended others
- `getPreferred` was implemented in `Negotiator`
- To do this the storage behind the scenes was changed, using an SplHeap instead of array to weight the order based on quality
- Added `AcceptItemInterface` to tie each accept header together
- `Negotiator`'s API was not broken, just internal classes
