### PR TITLE
Add default values for language and charset 

### DIFF
--- a/lib/BadFaith/Negotiator.php
+++ b/lib/BadFaith/Negotiator.php
@@ -42,9 +42,9 @@ class Negotiator
 
     static protected $keys = array(
         'accept',
-        'accept_charset',
-        'accept_encoding',
-        'accept_language',
+        'accept_charset' => 'utf-8',
+        'accept_encoding' => '',
+        'accept_language' => 'en-US',
     );
 
     /**
@@ -70,8 +70,8 @@ class Negotiator
     {
         $headers = array();
 
-        foreach (static::$keys as $key) {
-            $headers[$key] = $_SERVER['HTTP_' . strtoupper($key)];
+        foreach (static::$keys as $key => $default) {
+            $headers[$key] = (isset($_SERVER['HTTP_' . strtoupper($key)])) ? $_SERVER['HTTP_' . strtoupper($key)] : $default;
         }
 
         $this->headersFromArg($headers);
@@ -82,7 +82,7 @@ class Negotiator
      */
     function headersFromArg(array $arg)
     {
-        foreach (static::$keys as $key) {
+        foreach (static::$keys as $key => $default) {
             $value = array_key_exists($key, $arg) ? $arg[$key] : '';
 
             $this->headerLiterals[$key] = $value;

--- a/lib/BadFaith/Negotiator.php
+++ b/lib/BadFaith/Negotiator.php
@@ -41,8 +41,8 @@ class Negotiator
     public $variants = array();
 
     static protected $keys = array(
-        'accept',
-        'accept_charset' => 'utf-8',
+        'accept'          => '',
+        'accept_charset'  => 'utf-8',
         'accept_encoding' => '',
         'accept_language' => 'en-US',
     );


### PR DESCRIPTION
Some browsers don't send charset and language in certain circumstances. It should handle these gracefully

> [error] [client 66.249.71.182] PHP Notice: Undefined index: HTTP_ACCEPT_CHARSET in /var/www/html/vendor/BadFaith/BadFaith/lib/BadFaith/Negotiator.php on line 74
> [error] [client 66.249.71.182] PHP Notice: Undefined index: HTTP_ACCEPT_LANGUAGE in /var/www/html/vendor/BadFaith/BadFaith/lib/BadFaith/Negotiator.php on line 74
> [error] [client 66.249.71.182] PHP Warning: Invalid argument supplied for foreach() in /var/www/html/vendor/BadFaith/BadFaith/lib/BadFaith/Negotiator.php on line 158
